### PR TITLE
Add the Godot Meta Toolkit to the README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -81,6 +81,10 @@ channel on the [Godot Contributors Chat](https://chat.godotengine.org/)!
 - [Notification Scheduler Plugin](https://github.com/godot-sdk-integrations/godot-notification-scheduler)
 - [Share Plugin](https://github.com/godot-sdk-integrations/godot-share)
 
+#### Meta HorizonOS
+
+- [Meta Toolkit](https://github.com/godot-sdk-integrations/godot-meta-toolkit)
+
 ### Audio
 
 - [FMOD](https://github.com/utopia-rise/fmod-gdextension) (external)


### PR DESCRIPTION
I'm not sure this is the best way to "categorize" this on the list - it's a tricky one.

An argument could be made that this should go under "Stores", because it does provide integration with Meta's Platform SDK, which gives store integration.

But it also includes general tools for releasing on Meta's headsets, including a simplified export configuration and a tool to setup Meta's XR simulator, which developers could take advantage of while completely ignoring the store integration. We also have a PR in the works that enables exporting for this platform from the Android editor, which (again) has noting to do with the store.

So, this is really more of a "platform integration" rather than a "store integration", which is why I've put it on the list under "Platforms".

However, I'm very open to other suggestions on how it could be put on the list!